### PR TITLE
More reliable _get_image in ObjParse.gd

### DIFF
--- a/addons/obj_exporter/ObjParse.gd
+++ b/addons/obj_exporter/ObjParse.gd
@@ -123,13 +123,19 @@ static func _get_image(mtl_filepath: String, tex_filename: String) -> Image:
 		prints("Debug: Mapping texture file", tex_filename)
 	var tex_filepath: String = tex_filename
 	if tex_filename.is_relative_path():
-		tex_filepath = "%s/%s" % [mtl_filepath.get_base_dir(), tex_filename]
+		tex_filepath = mtl_filepath.get_base_dir().path_join(tex_filename).strip_edges()
 	var file_type: String = tex_filepath.get_extension()
 	if debug:
 		prints("Debug: texture file path:", tex_filepath, "of type", file_type)
-	
+
 	var img: Image = Image.new()
-	img.load(tex_filepath)
+	var err := img.load(tex_filepath)
+	if err != OK:
+		prints('Could not load texture %s: %s (%s)'%[
+			tex_filepath,
+			error_string(err),
+			err,
+		])
 	return img
 
 static func _create_texture(data: PackedByteArray) -> ImageTexture:


### PR DESCRIPTION
Stripped spaces from material file name to cover unexpected encoding with extra spaces.
Also added some debugging code when loading the texture doesn't work.