### PR TITLE
Update ObjParse.gd

### DIFF
--- a/addons/obj_exporter/ObjParse.gd
+++ b/addons/obj_exporter/ObjParse.gd
@@ -94,10 +94,11 @@ static func _create_mtl(obj: String, textures: Dictionary) -> Dictionary:
 				pass
 			"newmtl":
 				# Create a new material
+				var mat_name := parts[1].strip_edges()
 				if debug:
-					prints("Adding new material", parts[1])
+					prints("Adding new material", mat_name)
 				currentMat = StandardMaterial3D.new()
-				mats[parts[1]] = currentMat
+				mats[mat_name] = currentMat
 			"Ka":
 				# Ambient color
 				#currentMat.albedo_color = Color(float(parts[1]), float(parts[2]), float(parts[3]))


### PR DESCRIPTION
Fixed missing string cleanup when parsing external obj material. Taking an uncleaned mat name would both the setup of the resulting material on Godot's side with some assets.